### PR TITLE
Testing to make header tabs remain at top of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,21 +14,21 @@
 		<h1>
 			TNS Times Official Webpage
 		</h1>
-		<div id="si-tab-holder">
-			<si-tab class="active" data-activates="tnst">
-				Home
-			</si-tab>
-			<si-tab data-activates="issues">
-				Issues
-			</si-tab>
-			<si-tab data-activates="updates">
-				Updates
-			</si-tab>
-			<si-tab data-activates="contact">
-				Contact
-			</si-tab>
-		</div>
 	</header>
+	<div id="si-tab-holder">
+		<si-tab class="active" data-activates="tnst">
+			Home
+		</si-tab>
+		<si-tab data-activates="issues">
+			Issues
+		</si-tab>
+		<si-tab data-activates="updates">
+			Updates
+		</si-tab>
+		<si-tab data-activates="contact">
+			Contact
+		</si-tab>
+	</div>
 	<section id="main-si-content-section">
 		<section id="updates">
 			<h2>TNS Times Updates</h2>

--- a/style.css
+++ b/style.css
@@ -28,7 +28,7 @@ body > header#main-si-header > h1 {
 	padding-top: 50px;
 	padding-bottom: 50px;
 }
-body > header#main-si-header > div#si-tab-holder {
+body > #si-tab-holder {
 	width: 100%;
 	display: flex;
 	flex-direction: row;
@@ -38,6 +38,7 @@ body > header#main-si-header > div#si-tab-holder {
 	align-content: flex-end;
 	position: sticky;
 	top: 28px;
+	background-color: greenyellow;
 }
 
 #si-tab-holder > si-tab {


### PR DESCRIPTION
Previously, the header tabs would scroll out of view when the page was scrolled vertically.

This patch aims to make it “stick” at the top of the page, even when scrolled.